### PR TITLE
removed removing empty txs

### DIFF
--- a/cron/util.js
+++ b/cron/util.js
@@ -23,11 +23,6 @@ async function vin(rpctx) {
 
       txIds.add(`${ vin.txid }:${ vin.vout }`);
     });
-
-    // Remove unspent transactions.
-    if (txIds.size) {
-      await UTXO.remove({ _id: { $in: Array.from(txIds) } });
-    }
   }
   return txin;
 }
@@ -43,9 +38,6 @@ async function vout(rpctx, blockHeight) {
   if (rpctx.vout) {
     const utxo = [];
     rpctx.vout.forEach((vout) => {
-      if (vout.value <= 0 || vout.scriptPubKey.type === 'nulldata') {
-        return;
-      }
 
       const to = {
         blockHeight,
@@ -76,9 +68,6 @@ async function vout(rpctx, blockHeight) {
  * @param {Object} rpctx The rpc object from the node.
  */
 async function addPoS(block, rpctx) {
-  // We will ignore the empty PoS txs.
-  if (rpctx.vin[0].coinbase && rpctx.vout[0].value === 0)
-    return;
 
   const txin = await vin(rpctx);
   const txout = await vout(rpctx, block.height);


### PR DESCRIPTION
the reason am doing this PR is that removing this info from blocks removes information that can be used to tell if the tx is a pos reward for example if you have a script trying to find the block reward it can be very hard to tell the different from transactions.